### PR TITLE
Fix build dist test with pyqt4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - chmod +x ./continuous_integration/travis/install.sh
-  - export PYTHONPATH=$HOME/build/PierreRaybaut/formlayout
 
 install: source ./continuous_integration/travis/install.sh;
 

--- a/continuous_integration/travis/build_dist_test.sh
+++ b/continuous_integration/travis/build_dist_test.sh
@@ -5,27 +5,9 @@ set -ex
 # Print basic testing info
 pip --version
 
-cd $HOME/build/PierreRaybaut/formlayout
-
-# Is the following really necessary?
-## Checkout the right branch
-#if [ $TRAVIS_PULL_REQUEST != "false" ] ; then
-#    git checkout travis_pr_$TRAVIS_PULL_REQUEST
-#else
-#    git checkout master
-#fi
-
-# Somehow, building the package is segfaulting when using PyQt4.
-# Here is the corresponding Travis log:
-#   [...]
-#   Writing formlayout-2.0.0a0/setup.cfg
-#   creating dist
-#   Creating tar archive
-#   ./continuous_integration/travis/build_dist_test.sh: line 23:  4944 Segmentation fault      (core dumped) python setup.py build sdist
-if [ "$USE_QT_API" = "PyQt5" ]; then
-  # Building universal wheel package
-  python setup.py sdist bdist_wheel --universal
+# Building universal wheel package
+python setup.py sdist bdist_wheel --universal
   
-  # Building Python source package
-  python setup.py build sdist
-fi
+# Building Python source package
+python setup.py build sdist
+

--- a/continuous_integration/travis/main_test.sh
+++ b/continuous_integration/travis/main_test.sh
@@ -4,6 +4,9 @@ set -ex
 
 # Tell formlayout we're testing our widgets in Travis
 export TEST_CI_WIDGETS=True
+# This assumes that we are running the tests from the git checkout
+# folder
+export PYTHONPATH=$PWD
 
 python formlayout.py
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,12 @@ Copyright © 2009-2016 Pierre Raybaut
 This software is licensed under the terms of the MIT license
 """
 
+# Work-around: to avoid a segmentation fault in fill_window () from
+# libz.so.1, zlib needs to be imported before PyQt4. See
+# https://github.com/ContinuumIO/anaconda-issues/issues/272 for more
+# details
+import zlib
+
 from formlayout import __version__ as version
 LIBNAME = 'formlayout'
 


### PR DESCRIPTION
There seems to be some problematic interaction between PyQt4 and zlib, see https://github.com/ContinuumIO/anaconda-issues/issues/272.

I found a work-around (importing zlib before PyQt4) and took the opportunity to set PYTHONPATH in a more robust manner so that Travis can run on anyone's fork.
