### PR TITLE
Arial font is not needed any more to run examples/advanced.py

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -56,18 +56,8 @@ install_pyside()
 }
 
 
-install_arial_font()
-{
-    # The next line is to avoid an interactive prompt asking to accept
-    # the EULA license
-    echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections;
-    sudo apt-get install ttf-mscorefonts-installer;
-}
-
 #==============================================================================
 # Main
 #==============================================================================
 
-# Arial is needed to run formlayout.py
-install_arial_font;
 install_conda;


### PR DESCRIPTION
since https://github.com/PierreRaybaut/formlayout/issues/19 has been fixed. It probably will make the Travis run a bit shorter too.

I'll wait for Travis to go green and merge this one.
